### PR TITLE
feat: add twitter card

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,3 +8,8 @@ staticDir = ['assets']
 
 [project]
   name = 'CloudNativePG'
+
+[params]
+  description = 'CloudNativePG - PostgreSQL Operator for Kubernetes'
+  images = ['images/hero_image.svg']
+

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -25,6 +25,7 @@
   <link href="{{ $styles.RelPermalink }}" rel="stylesheet" />
   <link rel="favicon" href="/favicon/favicon.ico">
   <script async defer src="https://buttons.github.io/buttons.js"></script>
+  {{ template "_internal/twitter_cards.html" . }}
 </head>
 
 <body>


### PR DESCRIPTION
Using the internal Hugo template `twitter`, we support the Twitter
card content that can be used to properly share content on Twitter.

Closes #72

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>