### PR TITLE
Add Grafana sidecar config in kube-stack-config

### DIFF
--- a/assets/documentation/1.18/samples/monitoring/kube-stack-config.yaml
+++ b/assets/documentation/1.18/samples/monitoring/kube-stack-config.yaml
@@ -63,5 +63,8 @@ grafana:
   # -- the grafana admin password
   adminPassword: prom-operator
   defaultDashboardsEnabled: false
+  sidecar:
+      dashboards:
+        enabled: true
 alertmanager:
   enabled: true


### PR DESCRIPTION
Grafana Sidecar Dashboards has to be enabled 

this PR is related to #106 