### PR TITLE
feat: dark mode

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -36,6 +36,12 @@ a {
     color: #E63054;
 }
 
+@media (prefers-color-scheme: dark) {
+    a {
+        color: #eb4444;
+    }
+}
+
 .red-1 {
     color: #E63054;
 }
@@ -357,6 +363,13 @@ header li {
 code {
     font-size: 0.85em;
     color: brown;
+}
+
+@media (prefers-color-scheme: dark) {
+    code {
+        font-size: 0.85em;
+        color: tan;
+    }
 }
 
 pre code {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -29,7 +29,7 @@
   {{ template "_internal/opengraph.html" . }}
 </head>
 
-<body>
+<body class="bg-white dark:bg-sky-800 text-black dark:text-neutral-200">
   <div class="h-screen w-screen">
     {{ partial "nav" . }}
 

--- a/layouts/authors/single.html
+++ b/layouts/authors/single.html
@@ -16,12 +16,11 @@
         <h3 class="text-xl font-bold mb-6">Posts by {{ .Params.name }}</h3>
         {{ $this_author := .Params.github }}
         {{ range (.Site.GetPage "/blog").Pages}}
+        <ul>
             {{ if eq .Params.author $this_author }}
-            <div class="column is-half">
-                <a href="{{ .RelPermalink }}">{{ .Params.title}}</a>
-                {{ partial "blog_datetime.html" . }}
-            </div>
+            <li><a href="{{ .RelPermalink }}">{{ .Params.title }}</a></li>
             {{ end }}
+        </ul>
         {{ end }}
     </div>
 

--- a/layouts/authors/single.html
+++ b/layouts/authors/single.html
@@ -16,11 +16,12 @@
         <h3 class="text-xl font-bold mb-6">Posts by {{ .Params.name }}</h3>
         {{ $this_author := .Params.github }}
         {{ range (.Site.GetPage "/blog").Pages}}
-        <ul>
             {{ if eq .Params.author $this_author }}
-            <li><a href="{{ .RelPermalink }}">{{ .Params.title }}</a></li>
+            <div class="column is-half">
+                <a href="{{ .RelPermalink }}">{{ .Params.title}}</a>
+                {{ partial "blog_datetime.html" . }}
+            </div>
             {{ end }}
-        </ul>
         {{ end }}
     </div>
 

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -15,7 +15,7 @@
             <!--Image and content preview starts here-->
 
             <a href="{{ .RelPermalink }}">
-                <div class="charcoal">
+                <div class="text-zinc-900 dark:text-zinc-300">
                     <dl>
                         <dt class="text-3xl my-5 font-bold">{{ .Title }}</dt>
                         <div class="flex text-xs gap-1.5">
@@ -32,7 +32,7 @@
                 <!--CTA-->
                 <div class="pt-10">
                     <a href="{{ .RelPermalink }}"
-                        class="bg-rose-600 py-4 px-12 rounded-full text-white text-xl">Continue Reading</a>
+                        class="bg-rose-600 dark:bg-rose-800 py-4 px-12 rounded-full text-white text-xl">Continue Reading</a>
                 </div>
                 <!--CTA-->
             </a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
 <section>
 
     <!-- Cards start here-->
-    <div class="w-full grid grid-cols-1 md:grid-cols-3 text-white bg-red-1 md:px-36 md:py-12 py-8">
+    <div class="w-full grid grid-cols-1 md:grid-cols-3 text-white bg-red-600 dark:bg-red-800 md:px-36 md:py-12 py-8">
         {{ range where .Site.Pages "Params.type" "card" }}
         {{ partial "card" . }}
         {{ end }}
@@ -32,7 +32,7 @@
         <div class="mx-auto md:py-24 md:px-56 px-4 py-8">
             <hr>
         </div>
-        <h1 class="md:text-5xl font-bold red-1 leading-10 md:pt-4 text-3xl">100%</h1>
+        <h1 class="md:text-5xl font-bold text-red-600 dark:text-red-800 leading-10 md:pt-4 text-3xl">100%</h1>
         <h1 class="md:text-5xl font-bold text-white leading-10 md:pt-4 text-3xl">Open Source</h1>
         <p class="md:text-xl text-white md:w-2/5 mx-auto mt-10 text-lg px-4">
             CloudNativePG is 100% open source and community-driven.
@@ -45,7 +45,7 @@
 
     <div class="text-center pt-24">
         <a href="https://github.com/cloudnative-pg/cloudnative-pg"
-            class="bg-red-1 py-4 px-12 rounded-full text-white text-xl">View on GitHub</a>
+            class="bg-red-600 dark:bg-red-800 py-4 px-12 rounded-full text-white text-xl">View on GitHub</a>
     </div>
 </section>
 {{ end }}

--- a/layouts/page/styleguide.html
+++ b/layouts/page/styleguide.html
@@ -9,7 +9,7 @@
              <!--Tile 1 start here-->
                 <div class="p-4 bg-white drop-shadow-md rounded-md border-2 border-slate-50 w-36">
                     <div>
-                        <div class="bg-red-1 w-28 h-32 rounded-lg"></div>
+                        <div class="bg-red-600 dark:bg-red-800 w-28 h-32 rounded-lg"></div>
                         <div class="pt-2"><h1>Red 1 - #E63054</h1></div>
                     </div>
                 </div>
@@ -75,7 +75,7 @@
                 <!--Tile 2 start here-->
                    <div class="p-4 bg-white drop-shadow-md rounded-md border-2 border-slate-50 w-36">
                        <div>
-                        <div class="bg-gray-4 w-28 h-32 rounded-lg"></div>
+                        <div class="bg-gray-800 dark:bg-gray-300 w-28 h-32 rounded-lg"></div>
                         <div class="pt-2"><h1>Gray 4 -#212C31</h1></div>
                        </div>
                    </div>

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -5,7 +5,7 @@
 </div>
 <div>
     <div>
-        <h1 class="text-lg charcoal font-bold">
+        <h1 class="text-lg text-zinc-900 dark:text-zinc-300 font-bold">
             <a href="/authors/{{ .Params.author  }}">{{$author.Params.name}}</a>
         </h1>
     </div>

--- a/layouts/partials/author_sidebar.html
+++ b/layouts/partials/author_sidebar.html
@@ -5,7 +5,7 @@
 </div>
 <div class="my-auto">
     <div>
-        <h1 class="text-lg charcoal font-bold">
+        <h1 class="text-lg text-zinc-900 dark:text-zinc-300 font-bold">
             {{$author.Params.name}}
         </h1>
     </div>

--- a/layouts/partials/blog_datetime.html
+++ b/layouts/partials/blog_datetime.html
@@ -1,5 +1,5 @@
-<div class="flex gap-2 text-sm charcoal opacity-75">
-    <h6 class="flex gap-2 text-sm charcoal">
+<div class="flex gap-2 text-sm text-zinc-900 dark:text-zinc-300 opacity-75">
+    <h6 class="flex gap-2 text-sm text-zinc-900 dark:text-zinc-300">
         {{ .PublishDate.Format "January 2, 2006" }}
         •
         {{ .ReadingTime }} minute{{ if (ne .ReadingTime 1) }}s{{ end }}

--- a/layouts/partials/blog_sidebar.html
+++ b/layouts/partials/blog_sidebar.html
@@ -25,7 +25,7 @@
         <div class="space-y-10 px-4">
             <!--card 1 starts here-->
             {{ range first 6  (.Site.GetPage "/blog").Pages}}
-            <div class="p-8 bg-white drop-shadow-md md:w-2/6 rounded-md border-2 border-slate-50 align-super inline-grid max-w-xs"
+            <div class="p-8 bg-white dark:bg-sky-800 text-black dark:text-neutral-200 drop-shadow-md md:w-2/6 rounded-md border-2 border-slate-50 dark:border-bg-slate-500 align-super inline-grid max-w-xs"
                 style="min-width: 260px;">
                 <!--User profile-->
                 <div class="flex gap-3 mb-2.5">
@@ -38,7 +38,7 @@
                         <img src="{{ .RelPermalink }}/{{ .Params.image.url }}" class="object-fill"
                             alt="Blog image">
                     </div>
-                    <div class="charcoal">
+                    <div class="text-zinc-900 dark:text-zinc-300">
                         <h2 class="text-lg my-2.5 font-bold">{{.Title}}</h2>
                     </div>
                     <!--Blog image and content preview-->

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,14 +1,14 @@
 <footer class="text-center pb-24">
-    <p class="text-sm charcoal md:w-1/2 mx-auto md:pt-10 px-6 pt-12">
+    <p class="text-sm text-zinc-900 dark:text-zinc-300 md:w-1/2 mx-auto md:pt-10 px-6 pt-12">
 
       &copy; The CloudNativePG Contributors.<br />
 
       <a href="https://www.linuxfoundation.org/trademark-usage/"
-        class="red-1">The Linux Foundation has registered trademarks and uses
+        class="text-red-600 dark:text-red-800 ">The Linux Foundation has registered trademarks and uses
         trademarks</a>.<br />
 
       <a href="https://www.postgresql.org/about/policies/trademarks"
-        class="red-1">Postgres, PostgreSQL and the Slonik Logo are trademarks or
+        class="text-red-600 dark:text-red-800">Postgres, PostgreSQL and the Slonik Logo are trademarks or
         registered trademarks of the PostgreSQL Community Association of Canada, and
         used with their permission</a>.
 

--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -3,13 +3,13 @@
     <div class="md:flex md:flex-row px-4 md:px-56 md:justify-between place-content-center">
       <div class="md:w-1/2">
         <h1 class="md:text-6xl font-bold cnp-blue text-3xl md:text-left text-center">{{.Title}}</h1>
-        <h1 class="md:text-6xl font-bold red-1 pt-2.5 text-3xl md:text-left text-center">{{.Params.subtitle}}</h1>
-        <p class=" gray-4 text-xl md:text-2xl font-light leading-10 py-5 container md:tracking-wider">
+        <h1 class="md:text-6xl font-bold text-red-600 dark:text-red-800 pt-2.5 text-3xl md:text-left text-center">{{.Params.subtitle}}</h1>
+        <p class=" text-gray-800 dark:text-gray-300 text-xl md:text-2xl font-light leading-10 py-5 container md:tracking-wider">
           {{ .Content | plainify }}
         </p>
         <div class="pt-7 md:text-left text-center">
           <a href="{{.Params.cta.url}}"
-            class="md:text-3xl bg-red-1 py-4 px-12 rounded-full text-white text-xl">{{.Params.cta.content| plainify}}</a>
+            class="md:text-3xl bg-red-600 dark:bg-red-800 py-4 px-12 rounded-full text-white text-xl">{{.Params.cta.content| plainify}}</a>
         </div>
       </div>
       <div class="md:ml-8 hidden md:block">

--- a/layouts/partials/info.html
+++ b/layouts/partials/info.html
@@ -1,6 +1,6 @@
 {{ if modBool .i 2 }}
 
-<div class="w-full bg-gray-1 py-16 md:px-56 px-4">
+<div class="w-full bg-gray-100 dark:bg-sky-700 py-16 md:px-56 px-4">
   <section class="container mx-auto text-left md:flex md:flex-row md:justify-between">
     <div class="md:block mx-auto my-auto hidden">
       <img src="{{ .context.Params.icon }}" alt="{{.context.Title}}" />
@@ -10,30 +10,30 @@
     </div>
     <div class="md:w-3/5 md:block">
       <h1 class="md:text-3xl py-4 font-medium cnp-blue text-2xl md:text-left text-center">{{ .context.Title }}</h1>
-      <p class="md:text-xl leading-8 gray-4 text-lg">{{ .context.Content }}</p>
+      <p class="md:text-xl leading-8 text-gray-800 dark:text-gray-300  text-lg">{{ .context.Content }}</p>
     </div>
   </section>
 </div>
 {{ else }}
-<div class="md:block hidden w-full  bg-white py-16 md:px-56">
+<div class="md:block hidden w-full  bg-white dark:bg-sky-800 text-black dark:text-neutral-200 py-16 md:px-56">
   <section class="container mx-auto text-left md:flex md:flex-row md:justify-between">
     <div class="md:w-3/5">
       <h1 class="md:text-3xl py-4 font-medium cnp-blue text-2xl">{{ .context.Title }}</h1>
-      <p class="md:text-xl leading-8 gray-4 text-lg">{{ .context.Content }}</p>
+      <p class="md:text-xl leading-8 text-gray-800 dark:text-gray-300  text-lg">{{ .context.Content }}</p>
     </div>
     <div class="items-center my-auto mx-auto">
       <img src="{{ .context.Params.icon }}" alt="{{.context.Title}}" class="mx-auto" />
     </div>
   </section>
 </div>
-<div class="md:hidden w-full  bg-white py-16 px-4">
+<div class="md:hidden w-full  bg-white dark:bg-sky-800 text-black dark:text-neutral-200 py-16 px-4">
   <section class="container text-left md:flex md:flex-row md:justify-between">
     <div class="mx-auto my-auto ">
       <img src="{{ .context.Params.icon }}" alt="{{.context.Title}}" class="h-20 mx-auto" />
     </div>
     <div class="md:w-3/5">
       <h1 class="md:text-3xl py-4 font-medium text-center cnp-blue text-2xl">{{ .context.Title }}</h1>
-      <p class="md:text-xl leading-8 gray-4 text-lg">{{ .context.Content }}</p>
+      <p class="md:text-xl leading-8 text-gray-800 dark:text-gray-300 text-lg">{{ .context.Content }}</p>
     </div>
   </section>
 </div>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -28,14 +28,14 @@
         </ul>
       </div>
       <!--For hamburger click-->
-      <div class="py-4 bg-gray-1 mt-5 hidden" id="navi-list">
-        <ul class="md:flex gap-14 text-2xl md:medium-gray charcoal">
+      <div class="py-4 bg-gray-100 dark:bg-sky-700 mt-5 hidden" id="navi-list">
+        <ul class="md:flex gap-14 text-2xl md:medium-gray text-zinc-900 dark:text-zinc-300">
           <li class="text-center py-4"><a href="/docs">Documentation</a></li>
           <li class="text-center py-4"><a href="/blog">Blog</a></li>
           <li class="text-center py-4"><a href="/support">Support</a></li>
           <li class="text-center py-4"><a href="/end_users">End Users</a></li>
         </ul>
-        <div class="flex gap-3 py-4 justify-center bg-gray-1 fill-cnp-blue">
+        <div class="flex gap-3 py-4 justify-center bg-gray-100 dark:bg-sky-700 fill-cnp-blue">
           <a href="https://github.com/cloudnative-pg/cloudnative-pg">
             <img src="/icons/Git.svg" alt="Github">
           </a>


### PR DESCRIPTION
provide dark mode support for the CloudNativePG website:

It's automatic, based on the media selector (trigger in macOS by System Preferences > General > Dark )

- background is dark-ish, because with fully dark black/gray, the logos were washed out
- undid most of the custom CSS classes, as they don't play well with tailwind CSS `dark:` item

It's not 100% but IMO it covers most of the fundamentals.
That said, I'm no designer and don't have good eye for color.

![Screen Shot 2023-07-06 at 12 21 17](https://github.com/cloudnative-pg/cloudnative-pg.github.io/assets/423864/b3ddd9be-1701-4d0e-9e80-2abbb908140a)
![Screen Shot 2023-07-06 at 12 21 29](https://github.com/cloudnative-pg/cloudnative-pg.github.io/assets/423864/c8c4ea45-52be-4729-8093-44ce975a5f95)
![Screen Shot 2023-07-06 at 12 21 41](https://github.com/cloudnative-pg/cloudnative-pg.github.io/assets/423864/265fae52-02a8-43f9-863f-6b6ba3c61227)
