### PR TITLE
fix: authors page article list

### DIFF
--- a/layouts/authors/single.html
+++ b/layouts/authors/single.html
@@ -16,14 +16,14 @@
         <h3 class="text-xl font-bold mb-6">Posts by {{ .Params.name }}</h3>
         {{ $this_author := .Params.github }}
         {{ range (.Site.GetPage "/blog").Pages}}
-        <ul>
             {{ if eq .Params.author $this_author }}
-            <li><a href="{{ .RelPermalink }}">{{ .Params.title }}</a></li>
+            <div class="column is-half">
+                <a href="{{ .RelPermalink }}">{{ .Params.title}}</a>
+                {{ partial "blog_datetime.html" . }}
+            </div>
             {{ end }}
-        </ul>
         {{ end }}
     </div>
-
 
     <!--Col 2 starts here-->
     <div class="space-y-10 md:pt-10">


### PR DESCRIPTION
Fix the wonky spacing and bad HTML structure of the article listing in the authors page.
And, align in style with the "categories" index pages.

FIXED
![Screen Shot 2023-07-06 at 12 23 16](https://github.com/cloudnative-pg/cloudnative-pg.github.io/assets/423864/4f1091e4-8416-4924-bd1b-c5cb471a3b2c)

WRONG
![Screen Shot 2023-07-06 at 12 22 47](https://github.com/cloudnative-pg/cloudnative-pg.github.io/assets/423864/3f6777a9-9dbe-4487-b028-12ae6ec57c20)
