### PR TITLE
Fix website repo link

### DIFF
--- a/content/support/_index.md
+++ b/content/support/_index.md
@@ -11,4 +11,4 @@ related to CloudNativePG.
 
 This list is provided in alphabetical order. If you want to add your company or
 yourself to this list, please open up a pull request for the
-[CloudNativePG website](https://github.com/cloudnative-pg/cloudnative-pg).
+[CloudNativePG website](https://github.com/cloudnative-pg/cloudnative-pg.github.io).


### PR DESCRIPTION
The homepage is in a repo separate from the main CNPG repo.