### PR TITLE
Add CloudRaft in Commercial Support Page of CloudNativePG 

### DIFF
--- a/content/support/CloudNativePG __ CloudRaft.md
+++ b/content/support/CloudNativePG __ CloudRaft.md
@@ -1,0 +1,3 @@
+﻿Organisation Name: CloudRaft
+Organisation Logo: <https://res.cloudinary.com/dfee67kdq/image/upload/v1710314614/logos/CLOUDRAFT-white-bg_raswaf.svg>
+Website Link: https://www.cloudraft.io/postgresql-consulting


### PR DESCRIPTION
We have added the required details in the file in the md format. We have also give a link from our [page](https://www.cloudraft.io/postgresql-consulting) to your site, in return we would love to get featured and get the link back to the same page. 