### PR TITLE
Update dead Slack links

### DIFF
--- a/content/blog/running-postgresql-the-kubernetes-way/index.md
+++ b/content/blog/running-postgresql-the-kubernetes-way/index.md
@@ -79,7 +79,7 @@ You can install it with `kubectl apply -f angus.yaml`, as with any other
 Kubernetes manifest.
 
 For more information, please refer to the [documentation for version 1.15.0](https://cloudnative-pg.io/docs/1.15.0/).
-Alternatively, reach out to us on [Slack](https://join.slack.com/t/cloudnativepg/shared_invite/zt-237bhehx3-htDW2kz2hKJxEhn1W4VTnw)
+Alternatively, reach out to us on [Slack](https://join.slack.com/t/cloudnativepg/shared_invite/zt-2vedd06pe-vMZf4wJ3l_H_hB3YCZ947A)
 or use [GitHub discussions](https://github.com/cloudnative-pg/cloudnative-pg/discussions).
 
 If you are physically in Valencia for KubeCon Europe 2022, come and say hello to us!

--- a/content/releases/cloudnative-pg-1-24.0-rc1-released/index.md
+++ b/content/releases/cloudnative-pg-1-24.0-rc1-released/index.md
@@ -118,7 +118,7 @@ the final release, currently planned for the end of August 2024.
 
 Become a valued member of our expanding open-source, vendor-neutral, and openly
 governed community! Engage with fellow users, exchange insights, and receive
-support. Join our [Slack channel](https://join.slack.com/t/cloudnativepg/shared_invite/zt-2ij5hagfo-B04EQ9DUlGFzD6GEHDqE0g)
+support. Join our [Slack channel](https://join.slack.com/t/cloudnativepg/shared_invite/zt-2vedd06pe-vMZf4wJ3l_H_hB3YCZ947A)
 and follow us on [Twitter](https://twitter.com/CloudNativePg) to stay informed
 about the latest news and announcements.
 

--- a/content/releases/cloudnative-pg-1-24.0-released/index.md
+++ b/content/releases/cloudnative-pg-1-24.0-released/index.md
@@ -78,7 +78,7 @@ until November 22nd, 2024.
 
 Become an active member of our growing open-source, vendor-neutral, and openly
 governed community! Engage with fellow users, share insights, and receive
-support. Join our [Slack channel](https://join.slack.com/t/cloudnativepg/shared_invite/zt-2ij5hagfo-B04EQ9DUlGFzD6GEHDqE0g)
+support. Join our [Slack channel](https://join.slack.com/t/cloudnativepg/shared_invite/zt-2vedd06pe-vMZf4wJ3l_H_hB3YCZ947A)
 and follow us on [Twitter](https://twitter.com/CloudNativePg) to stay
 up-to-date with the latest news and announcements.
 

--- a/content/releases/cloudnative-pg-1-24.1-released/index.md
+++ b/content/releases/cloudnative-pg-1-24.1-released/index.md
@@ -56,7 +56,7 @@ Note that 1.23 will be supported until **November 22, 2024**.
 ## Join the Community
 
 Become part of our open-source, vendor-neutral community! Join our
-[Slack channel](https://join.slack.com/t/cloudnativepg/shared_invite/zt-2ij5hagfo-B04EQ9DUlGFzD6GEHDqE0g)
+[Slack channel](https://join.slack.com/t/cloudnativepg/shared_invite/zt-2vedd06pe-vMZf4wJ3l_H_hB3YCZ947A)
 and follow us on [Twitter](https://twitter.com/CloudNativePg) to stay updated
 on the latest news and developments.
 

--- a/content/releases/cloudnative-pg-1-25.0-rc1-released/index.md
+++ b/content/releases/cloudnative-pg-1-25.0-rc1-released/index.md
@@ -82,7 +82,7 @@ Additional RCs may follow as needed before the final release, planned in Decembe
 
 Join our vibrant, open-source, vendor-neutral community! Connect with us on:
 
-- [Slack](https://join.slack.com/t/cloudnativepg/shared_invite/zt-237bhehx3-htDW2kz2hKJxEhn1W4VTnw) for discussions and support.
+- [Slack](https://join.slack.com/t/cloudnativepg/shared_invite/zt-2vedd06pe-vMZf4wJ3l_H_hB3YCZ947A) for discussions and support.
 - [Twitter](https://twitter.com/CloudNativePg) for the latest updates and
   announcements.
 

--- a/content/releases/cloudnative-pg-1-25.0-released/index.md
+++ b/content/releases/cloudnative-pg-1-25.0-released/index.md
@@ -91,7 +91,7 @@ version 1.24 will continue until **March 23, 2025**.
 Join our vibrant, open-source community to connect with fellow CloudNativePG users, share insights, and get support:
 
 - **Slack**: Engage with us on
-  [Slack](https://join.slack.com/t/cloudnativepg/shared_invite/zt-2ij5hagfo-B04EQ9DUlGFzD6GEHDqE0g).
+  [Slack](https://join.slack.com/t/cloudnativepg/shared_invite/zt-2vedd06pe-vMZf4wJ3l_H_hB3YCZ947A).
 - **Twitter**: Follow
   [@CloudNativePg](https://twitter.com/CloudNativePg) for updates and news.
 

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -58,7 +58,7 @@
         <a class="github-button" href="https://github.com/cloudnative-pg/cloudnative-pg"
           data-color-scheme="no-preference: light; light: light; dark: dark;" data-size="large" data-show-count="true"
           aria-label="Star cloudnative-pg/cloudnative-pg on GitHub">Star</a>
-        <a href="https://join.slack.com/t/cloudnativepg/shared_invite/zt-237bhehx3-htDW2kz2hKJxEhn1W4VTnw">
+        <a href="https://join.slack.com/t/cloudnativepg/shared_invite/zt-2vedd06pe-vMZf4wJ3l_H_hB3YCZ947A">
           <img src="/icons/Slack.svg" alt="Slack" title="Join our Slack channel now!">
         </a>
         <a href="https://twitter.com/CloudNativePg">


### PR DESCRIPTION
Ran into some dead Slack join links when browsing the website. This updates every instance that I could find to match the link [here](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/CONTRIBUTING.md#ask-for-help).