### PR TITLE
Enable Google Analytics via Hugo service

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,10 @@ staticDir = ['assets']
 [project]
   name = 'CloudNativePG'
 
+[services]
+  [services.googleAnalytics]
+    id = 'G-SJWWHL48V3'
+
 [params]
   description = 'CloudNativePG - PostgreSQL Operator for Kubernetes'
   images = ['images/hero_image.png']
-

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -27,6 +27,9 @@
   <script async defer src="https://buttons.github.io/buttons.js"></script>
   {{ template "_internal/twitter_cards.html" . }}
   {{ template "_internal/opengraph.html" . }}
+  {{ if hugo.IsProduction -}}
+    {{ template "_internal/google_analytics.html" . -}}
+  {{ end -}}
 </head>
 
 <body>


### PR DESCRIPTION
- Contributes to #276
- I've tested this locally and the events are push to the GA4 measurement ID:
  > <img width="388" alt="image" src="https://github.com/user-attachments/assets/200dd056-830c-4bab-b3f7-fdf6dbd6847c" />