### PR TITLE
feat: order end users by weight (chronological)

### DIFF
--- a/content/end_users/README.md
+++ b/content/end_users/README.md
@@ -1,0 +1,31 @@
+---
+build:
+  list: never
+  publishResources: false
+  render: never
+---
+
+# End Users section order
+
+Each Markdown entry in the `end_users` directory (except this README file)
+should have a `weight` in the Hugo preamble, like so:
+
+``` txt
+---
+title: Shinkansen
+image: logo/shinkansen.png
+homepage: https://shinkansen.finance/
+weight: 44
+---
+```
+
+The weight should be computed so that entries are displayed in the End Users
+page in chronological order, the oldest entries at the top.
+
+The entries in this directory are based in the CNPG [ADOPTERS.md](https://github.com/cloudnative-pg/cloudnative-pg/blob/e5ef2fdaccd2c8fbdbf319f1224a0f90bbcfed30/ADOPTERS.md)
+file.
+To ensure the weights of end-users don't need modification as more and more are
+added, we should use as `weight` of an end user, the line it appears in, in the
+ADOPTERS file.
+
+E.g. Shinkansen is in line 44, whereas EDB is in line 34.

--- a/content/end_users/README.md
+++ b/content/end_users/README.md
@@ -15,7 +15,7 @@ should have a `weight` in the Hugo preamble, like so:
 title: Shinkansen
 image: logo/shinkansen.png
 homepage: https://shinkansen.finance/
-weight: 44
+weight: 11
 ---
 ```
 
@@ -28,4 +28,5 @@ To ensure the weights of end-users don't need modification as more and more are
 added, we should use as `weight` of an end user, the line it appears in, in the
 ADOPTERS file.
 
-E.g. Shinkansen is in line 44, whereas EDB is in line 34.
+E.g. Shinkansen is in line 44, whereas EDB is in line 34. We subtract 33 so we
+begin at 1. So, for EDB `weight: 1`, and for Shinkansen, `weight: 11`.

--- a/content/end_users/README.md
+++ b/content/end_users/README.md
@@ -25,7 +25,7 @@ page in chronological order, the oldest entries at the top.
 The entries in this directory are based in the CNPG [ADOPTERS.md](https://github.com/cloudnative-pg/cloudnative-pg/blob/e5ef2fdaccd2c8fbdbf319f1224a0f90bbcfed30/ADOPTERS.md)
 file.
 To ensure the weights of end-users don't need modification as more and more are
-added, we should use as `weight` of an end user, the line it appears in, in the
+added, we should use as `weight` of an end user, its ordering in the
 ADOPTERS file.
 
 E.g. Shinkansen is in line 44, whereas EDB is in line 34. We subtract 33 so we

--- a/content/end_users/_index.md
+++ b/content/end_users/_index.md
@@ -15,4 +15,4 @@ If you want to add your organization, please open a pull request for the
 [ADOPTERS file](https://github.com/cloudnative-pg/cloudnative-pg/blob/main/ADOPTERS.md).
 
 
-Below is a list of several CloudNativePG end users, in alphabetical order.
+Below is a list of several CloudNativePG end users, in chronological order.

--- a/content/end_users/biganimal.md
+++ b/content/end_users/biganimal.md
@@ -2,7 +2,7 @@
 title: BigAnimal
 image: logo/biganimal.svg
 homepage: https://biganimal.com
-weight: 34
+weight: 1
 ---
 
 BigAnimal is a fully managed database-as-a-service with built-in Oracle

--- a/content/end_users/biganimal.md
+++ b/content/end_users/biganimal.md
@@ -2,6 +2,7 @@
 title: BigAnimal
 image: logo/biganimal.svg
 homepage: https://biganimal.com
+weight: 34
 ---
 
 BigAnimal is a fully managed database-as-a-service with built-in Oracle

--- a/content/end_users/shinkansen.md
+++ b/content/end_users/shinkansen.md
@@ -2,7 +2,7 @@
 title: Shinkansen
 image: logo/shinkansen.png
 homepage: https://shinkansen.finance/
-weight: 44
+weight: 11
 ---
 
 Shinkansen moves your money at the speed of the internet

--- a/content/end_users/shinkansen.md
+++ b/content/end_users/shinkansen.md
@@ -2,6 +2,7 @@
 title: Shinkansen
 image: logo/shinkansen.png
 homepage: https://shinkansen.finance/
+weight: 44
 ---
 
 Shinkansen moves your money at the speed of the internet

--- a/layouts/paged_content/list.html
+++ b/layouts/paged_content/list.html
@@ -5,7 +5,7 @@
     <p>{{.Content}}</p>
 
     {{ $ps := .Paginate (union .Pages .Sections) }}
-    {{ range sort $ps.Pages "Title" }}
+    {{ range sort $ps.Pages "Weight" }}
     <hr>
     {{ if .Params.image }}
     <a href="{{ .Params.homepage }}">


### PR DESCRIPTION
Assumes the end users have a `weight` set in the front matter,
such that it is chronological in order.
This patch ensures the entries will be rendered by that weight
instead of alphabetically.
