### PR TITLE
Change Support page to a list layout

### DIFF
--- a/content/support/_index.md
+++ b/content/support/_index.md
@@ -1,6 +1,6 @@
 ---
 Title: Commercial Support
-type: paged_content
+type: support
 ---
 
 **CloudNativePG** is an independent open-source project and does not endorse

--- a/layouts/support/list.html
+++ b/layouts/support/list.html
@@ -1,0 +1,14 @@
+{{ define "main" }}
+
+<div class="mx-auto md:w-1/2 px-4 well">
+    <h2 class="text-xl mt-6">{{.Title}}</h2>
+    <p>{{.Content}}</p>
+    <ul>
+    {{ $ps := .Paginate (union .Pages .Sections) }}
+    {{ range sort $ps.Pages "Title" }}
+        <li><a href="{{ .Params.homepage }}">{{ .Title }}</a></li>
+    {{ end }}  
+    </ul>
+    <hr>
+</div>
+{{ end }}

--- a/layouts/support/list.html
+++ b/layouts/support/list.html
@@ -4,8 +4,7 @@
     <h2 class="text-xl mt-6">{{.Title}}</h2>
     <p>{{.Content}}</p>
     <ul>
-    {{ $ps := .Paginate (union .Pages .Sections) }}
-    {{ range sort $ps.Pages "Title" }}
+    {{ range sort .Pages "Title" }}
         <li><a href="{{ .Params.homepage }}">{{ .Title }}</a></li>
     {{ end }}  
     </ul>


### PR DESCRIPTION
The Support page was a long scroll with all the logos. Instead this is just a linked list, a lot more clean, offering an overview at a glance. Thanks @jsilvela for your support (get it?) on this one!