### PR TITLE
chore: added missing CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# The CODEOWNERS file is used to define individuals or teams that are
+# responsible for code in a repository. For details, please refer to
+# https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+* @cloudnative-pg/maintainers
+
+# Component owners
+# See https://github.com/cloudnative-pg/governance/blob/main/COMPONENT-OWNERS.md#cloudnative-pg
+
+# Website team
+* @cloudnative-pg/web


### PR DESCRIPTION
The CODEOWNERS file was missing, adding with the two initial teams:
* maintainers
* web