### PR TITLE
fix: recognize page author by id not just github

### DIFF
--- a/archetypes/authors/index.md
+++ b/archetypes/authors/index.md
@@ -2,4 +2,5 @@
 name:  {{ .Name | title}}
 avatar: temp-avatar.png
 github: {{ .Name }}
+id: {{ .Name }}
 ---

--- a/content/authors/fdrees/index.md
+++ b/content/authors/fdrees/index.md
@@ -2,6 +2,7 @@
 name: Floor Drees
 avatar: floor.jpg
 github: floord
+id: fdrees
 ---
 
 Open Source community advocate and Principal Program Manager at EDB. PostgreSQL Code of Conduct Committee member, PG EU Diversity Committee member, PGDay Lowlands organizer. 

--- a/content/authors/jgonzalez/index.md
+++ b/content/authors/jgonzalez/index.md
@@ -2,6 +2,7 @@
 name:  Jonathan Gonzalez V.
 avatar: jgonzalez-gh.jpeg
 github: sxd
+id: jgonzalez
 ---
 
 A free software lover, passionate about OpenSource and all the tools that

--- a/layouts/authors/single.html
+++ b/layouts/authors/single.html
@@ -14,9 +14,10 @@
         </div>
 
         <h3 class="text-xl font-bold mb-6">Posts by {{ .Params.name }}</h3>
-        {{ $this_author := .Params.github }}
+        {{ $author_git := .Params.github }}
+        {{ $author_id := .Params.id }}
         {{ range (.Site.GetPage "/blog").Pages}}
-            {{ if eq .Params.author $this_author }}
+            {{ if or (eq .Params.author $author_git) (eq .Params.author $author_id) }}
             <div class="column is-half">
                 <a href="{{ .RelPermalink }}">{{ .Params.title}}</a>
                 {{ partial "blog_datetime.html" . }}


### PR DESCRIPTION
Adds a new id field to author pages, and allows to recognize article ownership

Closes #334 