### PR TITLE
docs: Repair links to official docs

### DIFF
--- a/content/blog/customizing-hcl/index.md
+++ b/content/blog/customizing-hcl/index.md
@@ -150,7 +150,7 @@ uploaded there instead of the `localhost:5000` registry used in the
 ### Step 3: Use it
 
 The only missing step to use the images is to update your 
-[Image Catalog / Cluster Image Catalog](https://cloudnative-pg.io/documentation/current/image_catalog/) 
+[Image Catalog / Cluster Image Catalog](https://cloudnative-pg.io/docs/devel/image_catalog/)
 with the newly built images.
 Test them and stage them through your environment.
 

--- a/content/blog/developing-webapps-with-cloudnative-pg/index.md
+++ b/content/blog/developing-webapps-with-cloudnative-pg/index.md
@@ -39,7 +39,7 @@ There are two powerful reasons:
 
 1. It makes available a lot of powerful components built by the Kubernetes
   community. For example, in the
-  [Quickstart guide](http://cloudnative-pg.io/documentation/current/quickstart/)
+  [Quickstart guide](http://cloudnative-pg.io/docs/devel/quickstart/)
   for CloudNativePG you will find a section that takes you through installing
   the [Prometheus Operator](https://prometheus-operator.dev), with a
   [Grafana](https://grafana.com) dashboard to get metrics for your database.
@@ -77,7 +77,7 @@ Here's the game plan:
 ### Hands-on
 
 If you don't yet have a local Kubernetes cluster, please refer to the
-[Quickstart guide](http://cloudnative-pg.io/documentation/current/quickstart/).
+[Quickstart guide](http://cloudnative-pg.io/docs/devel/quickstart/).
 You will need `kind` installed, as well as `kubectl` and `docker`.
 If you want to run and compile the webapp locally to kick the tires, you will
 also need the [Go compiler](https://go.dev) - though this is not necessary if
@@ -105,7 +105,7 @@ several worker nodes with KinD.
 #### CloudNativePG operator
 
 Now let's install the CloudNativePG operator. As explained in the
-[installation document](https://cloudnative-pg.io/documentation/current/installation_upgrade/),
+[installation document](https://cloudnative-pg.io/docs/devel/installation_upgrade/),
 you can deploy it by applying the latest manifest.
 At the time of this writing, this is version 1.20.1:
 
@@ -159,7 +159,7 @@ kubectl apply -f \
 This YAML is part of a set of example cluster manifests provided with
 CloudNativePG that show off various features and are ready to deploy.
 You can find out more
-[in the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/samples/).
+[in the CloudNativePG documentation](https://cloudnative-pg.io/docs/devel/samples/).
 
 In a few seconds, you should have the PostgreSQL cluster `cluster-example` up
 and ready. It is a 3-instance cluster, with a primary and two hot-standbys.
@@ -379,7 +379,7 @@ saw the possibility of doing port-forwarding. Port-forwarding could be used to
 expose one or more of the CloudNativePG services over regular TCP ports.
 Credentials too would be handled without much trouble.
 
-For further information, please refer to the [use cases discussion](https://cloudnative-pg.io/documentation/current/use_cases/).
+For further information, please refer to the [use cases discussion](https://cloudnative-pg.io/docs/devel/use_cases/).
 
 ### Where to go from here
 
@@ -419,12 +419,12 @@ are tradeoffs that you can now explore meaningfully at development time.
 You could add connection pooling. CloudNativePG offers support out of the
 box for [PgBouncer](https://www.pgbouncer.org/) through the `Pooler` resource.
 You can find more information in the
-[connection pooling document](https://cloudnative-pg.io/documentation/current/connection_pooling/).
+[connection pooling document](https://cloudnative-pg.io/docs/devel/connection_pooling/).
 
 There's a lot of power to experiment and iterate through your system design.
 
 We mentioned in the beginning that the
-[quickstart guide](http://cloudnative-pg.io/documentation/current/quickstart/)
+[quickstart guide](http://cloudnative-pg.io/docs/devel/quickstart/)
 takes you through adding Prometheus / Grafana monitoring for your database
 cluster. It would not be difficult to publish Prometheus metrics for your
 webserver too, and have a dashboard for your full system.

--- a/content/blog/hasura-graphql/index.md
+++ b/content/blog/hasura-graphql/index.md
@@ -39,7 +39,7 @@ for details.
 ## Installing CloudNativePG
 
 To install CloudNativePG, we'll follow the [installation and
-upgrade](https://cloudnative-pg.io/documentation/current/installation_upgrade/)
+upgrade](https://cloudnative-pg.io/docs/devel/installation_upgrade/)
 section of the CloudNativePG website.
 
 At the time of writing, the latest version is 1.20. The following

--- a/content/blog/hasura-graphql/index.md
+++ b/content/blog/hasura-graphql/index.md
@@ -65,7 +65,7 @@ architecture with a primary database node and two replicas. We can simply
 apply the example manifest included with CloudNativePG:
 
 ``` sh
-$ kubectl apply -f https://cloudnative-pg.io/documentation/1.20/samples/cluster-example.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/refs/heads/release-1.20/docs/src/samples/cluster-example.yaml
 cluster.postgresql.cnpg.io/cluster-example created
 ```
 

--- a/content/blog/migrations-with-atlas-and-cloudnativepg/index.md
+++ b/content/blog/migrations-with-atlas-and-cloudnativepg/index.md
@@ -43,7 +43,7 @@ Let's see an example of how to do that:
 First of all, you should have CloudNativePG running on your kubernetes cluster,
 and a Postgres cluster created with CloudNativePG.
 If you don't yet have this, you can follow the
-[CloudNativePG quickstart](https://cloudnative-pg.io/documentation/current/quickstart/).
+[CloudNativePG quickstart](https://cloudnative-pg.io/docs/devel/quickstart/).
 
 Whether you follow the quickstart or you already had a CloudNativePG/Postgres
 cluster up and running, we'll assume for the rest of this post that your

--- a/content/blog/postgresql-16-beta1/index.md
+++ b/content/blog/postgresql-16-beta1/index.md
@@ -58,7 +58,7 @@ PostgreSQL 16beta1 (Debian 16~beta1-2.pgdg110+1) on x86_64-pc-linux-gnu,
 
 If you are interested in trying CloudNativePG on your laptop with 'kind'
 (Kubernetes in Docker), follow the instructions you find in the
-[Quickstart](https://cloudnative-pg.io/documentation/current/quickstart/).
+[Quickstart](https://cloudnative-pg.io/docs/devel/quickstart/).
 
 One last note: at the moment, PGAudit is not compatible with PostgreSQL 16
 and cannot be used with the operator. There's a

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -9,7 +9,7 @@
         <h3 class="text-3xl font-semibold mb-0">Learn</h3>
         <div class="space-y-2 text-base text-red-500">
           <div><a href="/docs" class="hover:text-red-700 transition">Documentation</a></div>
-          <div><a href="https://cloudnative-pg.io/documentation/current/quickstart/"
+          <div><a href="https://cloudnative-pg.io/docs/devel/quickstart/"
               class="hover:text-red-600 transition">Quickstart Guide</a></div>
           <div><a href="/tags/tutorial" class="hover:text-red-600 transition">Tutorials</a></div>
         </div>


### PR DESCRIPTION
The outdated docs link in https://github.com/cloudnative-pg/cloudnative-pg/pull/9548 is also present in the footer of the CNPG site, and in a few blogposts as well.