### PR TITLE
Replace rel="favicon" with rel="icon"

### DIFF
--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -23,7 +23,7 @@
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
   {{ end -}}
   <link href="{{ $styles.RelPermalink }}" rel="stylesheet" />
-  <link rel="favicon" href="/favicon/favicon.ico">
+  <link rel="icon" href="/favicon/favicon.ico">
   <script async defer src="https://buttons.github.io/buttons.js"></script>
   {{ template "_internal/twitter_cards.html" . }}
   {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
Fixes #405  
This change updates it to rel="icon" instead of rel="favicon", as recommended by MDN docs and the HTML specification.