### PR TITLE
Remove name from quote Rewe

### DIFF
--- a/content/end_users/rewe.md
+++ b/content/end_users/rewe.md
@@ -7,4 +7,4 @@ weight: 17
 
 > _We've been using CloudNativePG since 2023 to support highly available databases and it's so much better than installing Postgres on VMs as it makes our life as DBAs and Platform Engineers so much easier. We had it up&running in no time and we're really excited about the future of the project especially now with the support of major upgrades._
 \
-— Ing. Marijo Kristo, Expert IT Operations, REWE International AG
+— REWE International AG


### PR DESCRIPTION
Former employee of Rewe has asked us to remove their name from the End Users page's quote, as per the GDPR regulations. I've left the quote un-attributed for now, we might need to find a new contact with the company. 